### PR TITLE
chore: wrap blocking calls with IO.blocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dafka-producer",
-    "version": "7.0.2",
+    "version": "7.0.3",
     "description": "Dockerized kafka producer ",
     "private": true,
     "repository": {

--- a/src/main/scala/adapters/endpoints/MonitoringService.scala
+++ b/src/main/scala/adapters/endpoints/MonitoringService.scala
@@ -2,25 +2,25 @@ package adapters
 package endpoints
 
 import cats.effect.IO
-import cats.implicits._
-import endpoints4s.http4s.server.Endpoints
+import endpoints4s.http4s.server.{Endpoints, JsonEntitiesFromSchemas}
 import org.http4s.HttpRoutes
 import ports.{MonitoringEndpoint, Producer}
 
-class MonitoringService(producer: Producer) extends Endpoints[IO] with MonitoringEndpoint{
-  val routes =
+class MonitoringService(producer: Producer)
+  extends Endpoints[IO]
+    with MonitoringEndpoint
+    with JsonEntitiesFromSchemas {
+
+  private def healthy (): IO[Boolean] = IO.interruptibleMany{
+    producer
+      .healthy()
+  }.flatMap(x => x)
+
+  val routes: HttpRoutes[IO] =
     HttpRoutes.of(
       routesFromEndpoints(
-        ready.implementedByEffect(_ => IO.blocking{
-          producer.healthy().map(res => res.toString)
-        })
-      )
-    ) <+>
-    HttpRoutes.of(
-      routesFromEndpoints(
-        alive.implementedByEffect(_ => IO.blocking{
-          producer.healthy().map(res => res.toString)
-        })
+        ready.implementedByEffect(_ => healthy()),
+        alive.implementedByEffect(_ => healthy())
       )
     )
 

--- a/src/main/scala/adapters/endpoints/MonitoringService.scala
+++ b/src/main/scala/adapters/endpoints/MonitoringService.scala
@@ -11,12 +11,16 @@ class MonitoringService(producer: Producer) extends Endpoints[IO] with Monitorin
   val routes =
     HttpRoutes.of(
       routesFromEndpoints(
-        ready.implementedByEffect(_ => producer.healthy().map(res => res.toString))
+        ready.implementedByEffect(_ => IO.blocking{
+          producer.healthy().map(res => res.toString)
+        })
       )
     ) <+>
     HttpRoutes.of(
       routesFromEndpoints(
-        alive.implementedByEffect(_ => producer.healthy().map(res => res.toString))
+        alive.implementedByEffect(_ => IO.blocking{
+          producer.healthy().map(res => res.toString)
+        })
       )
     )
 

--- a/src/main/scala/adapters/endpoints/ProduceService.scala
+++ b/src/main/scala/adapters/endpoints/ProduceService.scala
@@ -22,7 +22,7 @@ class ProduceService(
         (for {
           _ <- logger.info("handling produce requests")
           // Remove when https://github.com/Banno/kafka4s/pull/516 is merged
-          _ <- IO.blocking{
+          _ <- IO.interruptibleMany{
             records
               .map(record =>
                 producer.produce(record)

--- a/src/main/scala/adapters/endpoints/ProduceService.scala
+++ b/src/main/scala/adapters/endpoints/ProduceService.scala
@@ -21,11 +21,14 @@ class ProduceService(
       produce.implementedByEffect(records=>
         (for {
           _ <- logger.info("handling produce requests")
-          _ <- records
-            .map(record =>
-              producer.produce(record)
-            )
-            .parSequence
+          // Remove when https://github.com/Banno/kafka4s/pull/516 is merged
+          _ <- IO.blocking{
+            records
+              .map(record =>
+                producer.produce(record)
+              )
+              .parSequence
+          }
           _ <- logger.info("messages produced successfully")
         } yield ProducerResponse(true)).handleErrorWith{throwable =>
           logger.error(throwable)("failed to handle producer request") *> IO.pure(ProducerResponse(false))

--- a/src/main/scala/ports/MonitoringEndpoint.scala
+++ b/src/main/scala/ports/MonitoringEndpoint.scala
@@ -2,17 +2,18 @@ package ports
 
 import endpoints4s.algebra
 
-trait MonitoringEndpoint  extends algebra.Endpoints{
+trait MonitoringEndpoint  extends algebra.Endpoints
+    with algebra.JsonEntitiesFromSchemas{
 
-  val alive : Endpoint[Unit, String] =
+  val alive : Endpoint[Unit, Boolean] =
     endpoint(
       get( path / "alive"),
-      ok(textResponse)
+      ok(jsonResponse[Boolean])
     )
 
-  val ready: Endpoint[Unit, String] =
+  val ready: Endpoint[Unit, Boolean] =
     endpoint(
       get(path / "ready"),
-      ok(textResponse)
+      ok(jsonResponse[Boolean])
     )
 }


### PR DESCRIPTION
Long read: https://typelevel.org/cats-effect/docs/schedulers

TL;DR: I am seeing this error and it is probably a bad sign 

```
2023-06-12T11:16:06.995Z [WARNING] Your app's responsiveness to a new asynchronous event (such as a new connection, an upstream response, or a timer) was in excess of 100 milliseconds. Your CPU is probably starving. Consider increasing the granularity of your delays or adding more cedes. This may also be a sign that you are unintentionally running blocking I/O operations (such as File or InetAddress) without the blocking combinator.
```

See this [explanation](https://typelevel.org/cats-effect/docs/core/starvation-and-tuning) to why this is probably happening - and this Banno/kafka4s#516 which is probably related