### PR TITLE
chore: use java 18

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ dist
 node_modules
 .gen
 bazel-*/
+BUILD
+WORKSPACE

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,7 +121,16 @@ container_repositories()
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
 
+load("@io_bazel_rules_docker//container:pull.bzl", container_pull="container_pull")
+
 container_deps()
+
+container_pull(
+    name = "java_base_image",
+    repository = "openjdk",
+    registry = "docker.io",
+    tag = "18"
+)
 
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dafka-producer",
-    "version": "7.0.6",
+    "version": "7.1.0",
     "description": "Dockerized kafka producer ",
     "private": true,
     "repository": {

--- a/src/BUILD
+++ b/src/BUILD
@@ -43,5 +43,6 @@ scala_binary(
 scala_image(
     name = "image",
     main_class = "Main",
+    base = "@java_base_image//image",
     runtime_deps = [":main"],
 )


### PR DESCRIPTION
Default is Java 11 and it seems like Java 18 has interesting changes around containers: https://developers.redhat.com/articles/2022/04/19/java-17-whats-new-openjdks-container-awareness#recent_changes_in_openjdk_s_container_awareness_code