### PR TITLE
fix: handle fatal producer errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dafka-producer",
-    "version": "7.2.3",
+    "version": "7.2.4",
     "description": "Dockerized kafka producer",
     "private": true,
     "repository": {

--- a/src/main/scala/adapters/kafka/ProducerImpl.scala
+++ b/src/main/scala/adapters/kafka/ProducerImpl.scala
@@ -42,6 +42,14 @@ class ProducerImpl(
         }).map(seq => seq.asJava).orNull
       )
     )).map(_ => ())
+      .handleErrorWith(e => {
+        if (e.getMessage =="Cannot execute transactional method because we are in an error state") {
+          logger.error(e)("Unrecoverable Kafka error, aborting")
+          System.exit(-5)
+        }
+
+        return IO.raiseError(e)
+      })
 
   override def healthy(): IO[Boolean] = {
     readinessTopic.map { topic =>

--- a/src/main/scala/adapters/kafka/ProducerImpl.scala
+++ b/src/main/scala/adapters/kafka/ProducerImpl.scala
@@ -48,7 +48,7 @@ class ProducerImpl(
           System.exit(-5)
         }
 
-        return IO.raiseError(e)
+        IO.raiseError(e)
       })
 
   override def healthy(): IO[Boolean] = {


### PR DESCRIPTION
See the discussion [here](https://issues.apache.org/jira/browse/KAFKA-8726), basically the error means the producer is practically dead so let's kill it 🤮 