### PR TITLE
feat: allow configuring any kafka producer property

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Container images are configured using parameters passed at runtime.
 | `TRUSTSTORE_PASSWORD` | `required` if `TRUSTORE_FILE_PATH != null` | Truststore's password |
 | `USE_PROMETHEUS` | `false` | Export metrics to Prometheus |
 | `PROMETHEUS_BUCKETS` | `0.003,0.03,0.1,0.3,1.5,10` | A list of Prometheus buckets to use |
+| `KAFKA_PROPERTY_*` | `null` | Any [producer config](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html), passed as is to the Kafka client. The name is lowercased and underscores become dots, so `KAFKA_PROPERTY_MAX_REQUEST_SIZE=5242880` sets `max.request.size=5242880`. Properties that have a dedicated parameter above (e.g. `LINGER_TIME_MS`) are not overridable this way |
 
 ## License
 MIT License

--- a/src/main/scala/config/KafkaConfig.scala
+++ b/src/main/scala/config/KafkaConfig.scala
@@ -7,6 +7,7 @@ import enumeratum.values.{StringCirisEnum, StringEnum, StringEnumEntry}
 import eu.timepit.refined.types.string.NonEmptyString
 
 import java.nio.file.Path
+import java.util.Locale
 
 final case class KafkaConfig(readinessTopic: Option[String], producerConfig: Seq[(String, AnyRef)])
 
@@ -21,6 +22,18 @@ object SASLMechanism extends StringEnum[SASLMechanism] with StringCirisEnum[SASL
 final case class SASLConfig(username: NonEmptyString, password: Secret[String], mechanism: SASLMechanism, truststoreFilePath: Option[Path], truststoreFilePassword: Option[Secret[String]])
 
 object KafkaConfig {
+  private val extraPropertyPrefix = "KAFKA_PROPERTY_"
+
+  // Any KAFKA_PROPERTY_* variable is passed to the Kafka client as a producer property,
+  // e.g. KAFKA_PROPERTY_MAX_REQUEST_SIZE=5242880 becomes max.request.size=5242880
+  private def extraProducerConfig(environment: Map[String, String]): Seq[(String, AnyRef)] =
+    environment.toSeq
+      .collect {
+        case (name, value) if name.startsWith(extraPropertyPrefix) && name.length > extraPropertyPrefix.length =>
+          (name.stripPrefix(extraPropertyPrefix).toLowerCase(Locale.ROOT).replace('_', '.'), value)
+      }
+      .sortBy { case (property, _) => property }
+
   implicit val pathDecoder: ConfigDecoder[String, Path] =
     ConfigDecoder[String, String]
       .map(path => Path.of(path))
@@ -79,7 +92,10 @@ object KafkaConfig {
           ("max.block.ms", maxBlockMS)
         ) ++ batchSize.map(size => Seq(("batch.size", size))).getOrElse(Seq())
 
-      KafkaConfig(readinessTopic, producerConfig)
+      val extraConfig = extraProducerConfig(sys.env)
+        .filterNot { case (property, _) => producerConfig.exists { case (name, _) => name == property } }
+
+      KafkaConfig(readinessTopic, producerConfig ++ extraConfig)
     }
   }
 }

--- a/tests/specs/extraKafkaProperties.spec.ts
+++ b/tests/specs/extraKafkaProperties.spec.ts
@@ -1,0 +1,37 @@
+import type {Orchestrator} from '../testcontainers/orchestrator.js';
+import {start} from '../testcontainers/orchestrator.js';
+
+const topic = 'my-topic';
+
+describe('tests', () => {
+    let orchestrator: Orchestrator;
+
+    beforeEach(async () => {
+        orchestrator = await start(
+            {
+                KAFKA_BROKER: 'kafka:9092',
+                MAX_BLOCK_MS: '1000',
+                KAFKA_PROPERTY_MAX_REQUEST_SIZE: '1024',
+            },
+            [topic]
+        );
+    }, 5 * 60 * 1000);
+
+    afterEach(async () => {
+        if (!orchestrator) {
+            return;
+        }
+        await orchestrator.stop();
+    });
+
+    it('extra kafka properties', async () => {
+        await expect(
+            orchestrator.dafkaProducer.produce([
+                {
+                    topic,
+                    value: {data: 'x'.repeat(2048)},
+                },
+            ])
+        ).rejects.toThrow(/max\.request\.size/);
+    });
+});


### PR DESCRIPTION
## Problem

The producer properties dafka-producer supports are a closed, hardcoded set: `linger.ms`, `batch.size`, `compression.type`, `max.block.ms`, plus broker/SASL wiring. Anything else a Kafka producer can be tuned with is unreachable, and each new knob has needed its own PR here (`feat: allow to configure batch size` #18, `MAX_BLOCK_MS`, `COMPRESSION_TYPE`…), plus a matching PR and release in the Helm chart.

We hit this with `max.request.size`. A service of ours produces webhook payloads that occasionally exceed the 1 MiB default, and dafka-producer rejects them with no way to raise the limit:

```
logger: adapters.endpoints.ProduceService
message: failed to handle producer request
exception: org.apache.kafka.common.errors.RecordTooLargeException: The message is 1161797 bytes when
serialized which is larger than 1048576, which is the value of the max.request.size configuration.
```

There is no workaround today: `JAVA_OPTS` doesn't help because config is read from the environment with ciris, not from JVM system properties.

## Change

Any `KAFKA_PROPERTY_*` environment variable is passed through to the Kafka client as a producer property. The name is lowercased and underscores become dots:

```
KAFKA_PROPERTY_MAX_REQUEST_SIZE=5242880   ->  max.request.size=5242880
KAFKA_PROPERTY_DELIVERY_TIMEOUT_MS=30000  ->  delivery.timeout.ms=30000
```

Anything the existing configuration already sets — `bootstrap.servers`, the serializers, `linger.ms`, `max.block.ms`, the SASL/TLS properties, and `batch.size`/`compression.type` when their variables are in play — is filtered out of the passthrough, so existing configuration always wins and the passthrough can't break the service.

## Why a passthrough rather than a `MAX_REQUEST_SIZE` variable

Adding one more `env("MAX_REQUEST_SIZE").option` to `KafkaConfig` would be a two-line change, so this is a judgement call:

- Kafka has ~40 producer properties. The bespoke route means a code change, an image release, a chart change and a chart release every time someone needs one of them, which is the pattern this repo has already repeated four times.
- The passthrough is additive and opt-in: with no `KAFKA_PROPERTY_*` set, the producer config is byte for byte what it is today.
- Enumerating variables isn't possible through ciris `env(...)`, so this reads `sys.env` directly, which the codebase already does for the cats-effect runtime config in `Main.scala`.

Happy to swap this for an explicit `MAX_REQUEST_SIZE` variable if you'd rather keep the config surface closed — say the word and I'll rework it.

## Tests

`tests/specs/extraKafkaProperties.spec.ts` starts the producer with `KAFKA_PROPERTY_MAX_REQUEST_SIZE=1024` and asserts that a 2 KB record is rejected with a `max.request.size` error. Testing the raise direction end to end would need the broker's `message.max.bytes` raised too and multi-MB payloads through the test harness, which felt like a worse trade against test stability — the assertion here already proves the property reaches the `KafkaProducer`, and the container passing its readiness probe proves the config is accepted.

## Notes

- The chart also needs a change before this is usable from Kubernetes: `dafka-producer-helm-chart` renders a fixed `env:` list with no passthrough, so chart users can't set a `KAFKA_PROPERTY_*` variable until it grows an `extraEnv`. Chart PR to follow.
- Unrelated, spotted while reading `KafkaConfig`: `compression.type` is only added to the producer config inside the `saslConfig.map { ... }` block, so `COMPRESSION_TYPE` is silently ignored when `USE_SASL_AUTH` is off. Left alone here to keep this PR to one change; happy to open a separate fix.