### PR TITLE
fix(build): migrate container image from archived rules_docker to rules_oci

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,17 +10,23 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
+            - name: Set up JDK
+              uses: actions/setup-java@v4
+              with:
+                  distribution: temurin
+                  java-version: '18'
             - name: Install bazelisk
               run: |
-                  curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64"
+                  curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64"
                   mkdir -p "${GITHUB_WORKSPACE}/bin/"
                   mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
                   chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+                  echo "${GITHUB_WORKSPACE}/bin" >> "${GITHUB_PATH}"
 
             - name: Docker meta
               id: docker_meta
-              uses: docker/metadata-action@v4
+              uses: docker/metadata-action@v5
               with:
                   images: |
                       ${{github.repository}}
@@ -28,13 +34,15 @@ jobs:
                       type=semver,pattern={{major}}.{{minor}}.{{patch}}
                       type=semver,pattern={{major}}.{{minor}}
                       type=semver,pattern={{major}}
+            # Must precede the Bazel build: oci_pull reads ~/.docker/config.json,
+            # so logging in first also lifts the anonymous Docker Hub pull limit.
             - name: Login to DockerHub
-              uses: docker/login-action@v1
+              uses: docker/login-action@v3
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
             - run: |
-                  bazel build //src:image.tar 
+                  bazel build //src:image.tar
                   docker load -i bazel-bin/src/image.tar
               name: Build base image with Bazel
             - name: Push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
 
             - run: yarn
             - run: |
-                  docker pull confluentinc/cp-kafka:7.2.2
+                  docker pull confluentinc/cp-kafka:7.6.0
                   yarn test
               env:
                   MAX_RETRIES: 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,18 +15,25 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Use Node.js
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v4
               with:
                   node-version: '18.x'
 
+            - name: Set up JDK
+              uses: actions/setup-java@v4
+              with:
+                  distribution: temurin
+                  java-version: '18'
+
             - name: Install bazelisk
               run: |
-                  curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64"
+                  curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64"
                   mkdir -p "${GITHUB_WORKSPACE}/bin/"
                   mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
                   chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+                  echo "${GITHUB_WORKSPACE}/bin" >> "${GITHUB_PATH}"
 
             - run: yarn
             - run: |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,14 +2,18 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-skylib_version = "1.0.3"
+skylib_version = "1.4.2"
 
 http_archive(
     name = "bazel_skylib",
-    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+    sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
     type = "tar.gz",
     url = "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
 )
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 load("//3rdparty:workspace.bzl", "maven_dependencies")
 
@@ -93,55 +97,62 @@ rules_proto_toolchains()
 register_toolchains("//toolchains:my_scala_toolchain")
 
 
-# bazel_docker ----------------------------------------------------------------
+# bazel_oci ----------------------------------------------------------------
 
 http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
+    name = "rules_pkg",
+    sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz"],
 )
 
-load(
-    "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
-    docker_toolchain_configure = "toolchain_configure",
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()
+
+# Pinned ahead of rules_oci_dependencies(), which would otherwise bring in
+# bazel-lib 1.42.1 — that release has no linux/arm64 jq toolchain.
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "6d758a8f646ecee7a3e294fbe4386daafbe0e5966723009c290d493f227c390b",
+    strip_prefix = "bazel-lib-2.7.7",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz",
 )
 
-docker_toolchain_configure(
-    name = "docker_config",
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")
+
+aspect_bazel_lib_dependencies()
+
+aspect_bazel_lib_register_toolchains()
+
+http_archive(
+    name = "rules_oci",
+    sha256 = "46ce9edcff4d3d7b3a550774b82396c0fa619cc9ce9da00c1b09a08b45ea5a14",
+    strip_prefix = "rules_oci-1.8.0",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.8.0/rules_oci-v1.8.0.tar.gz",
 )
-# End of OPTIONAL segment.
 
-load(
-    "@io_bazel_rules_docker//repositories:repositories.bzl",
-    container_repositories = "repositories",
+load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
+
+rules_oci_dependencies()
+
+load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
+
+oci_register_toolchains(
+    name = "oci",
+    crane_version = LATEST_CRANE_VERSION,
 )
 
-container_repositories()
+load("@rules_oci//oci:pull.bzl", "oci_pull")
 
-load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
-load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
-
-load("@io_bazel_rules_docker//container:pull.bzl", container_pull="container_pull")
-
-container_deps()
-
-container_pull(
+# `openjdk:18` was withdrawn from Docker Hub; eclipse-temurin is the successor
+# named in the openjdk image's own deprecation notice.
+oci_pull(
     name = "java_base_image",
-    repository = "openjdk",
-    registry = "docker.io",
-    tag = "18"
+    digest = "sha256:1b8a5c3f4dd3c1ece138bd0d011aa708cc0448be48b037af38f577416aa85744",
+    image = "docker.io/library/eclipse-temurin",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+    ],
+    tag = "18-jdk",
 )
-
-load(
-    "@io_bazel_rules_docker//repositories:repositories.bzl",
-    container_repositories = "repositories",
-)
-
-container_repositories()
-
-load(
-    "@io_bazel_rules_docker//scala:image.bzl",
-    _scala_image_repos = "repositories",
-)
-
-_scala_image_repos()

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,5 +1,7 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library", "scala_test")
-load("@io_bazel_rules_docker//scala:image.bzl", "scala_image")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 scala_library(
     name = "lib",
@@ -40,9 +42,41 @@ scala_binary(
     deps = [":lib"],
 )
 
-scala_image(
+copy_file(
+    name = "app_jar",
+    src = ":main_deploy.jar",
+    out = "dafka-producer.jar",
+)
+
+pkg_tar(
+    name = "app_layer",
+    srcs = [":app_jar"],
+    package_dir = "/app",
+)
+
+oci_image(
     name = "image",
-    base = "@java_base_image//image",
-    main_class = "Main",
-    runtime_deps = [":main"],
+    base = "@java_base_image",
+    entrypoint = [
+        "java",
+        "-cp",
+        "/app/dafka-producer.jar",
+        "Main",
+    ],
+    env = {"JAVA_RUNFILES": "/app"},
+    tars = [":app_layer"],
+)
+
+oci_tarball(
+    name = "image_tarball",
+    image = ":image",
+    repo_tags = ["bazel/src:image"],
+)
+
+# `//src:image.tar` in `bazel-bin/src/` is the contract the release workflow and
+# the `pretest` script rely on; oci_tarball writes to `image_tarball/tarball.tar`.
+copy_file(
+    name = "image_tar",
+    src = ":image_tarball",
+    out = "image.tar",
 )

--- a/tests/testcontainers/kafka.ts
+++ b/tests/testcontainers/kafka.ts
@@ -4,7 +4,7 @@ import {Kafka, logLevel} from 'kafkajs';
 import delay from 'delay';
 
 export const kafka = async (network: StartedNetwork, topics: string[]) => {
-    const container = await new KafkaContainer('confluentinc/cp-kafka:7.2.2')
+    const container = await new KafkaContainer('confluentinc/cp-kafka:7.6.0')
         .withNetwork(network)
         .withNetworkAliases('kafka')
         .withWaitStrategy(Wait.forLogMessage('started (kafka.server.KafkaServer)'))


### PR DESCRIPTION
## What was broken

`bazel build //src:image.tar` — the target both the release workflow and `yarn pretest` depend on — cannot complete. The last image published to Docker Hub is `7.3.0` from 2024-03-21. There are three independent breakages stacked on top of each other.

### 1. `rules_docker`'s prebuilt Go binaries are gone (the hard blocker)

`container_repositories()` declares `http_file` targets pointing at a Google Cloud Storage bucket that no longer serves anonymous reads. Every one of them 403s:

```
https://storage.googleapis.com/rules_docker/aad94363e63d31d574cf701df484b3e8b868a96a/puller-darwin-amd64  -> 403
https://storage.googleapis.com/rules_docker/aad94363e63d31d574cf701df484b3e8b868a96a/puller-linux-amd64   -> 403
https://storage.googleapis.com/rules_docker/aad94363e63d31d574cf701df484b3e8b868a96a/puller-linux-arm64   -> 403
https://storage.googleapis.com/rules_docker/aad94363e63d31d574cf701df484b3e8b868a96a/loader-linux-amd64   -> 403
```

The bucket itself denies listing (`AccessDenied` on `storage.objects.list`), so this is a withdrawn bucket, not four missing objects. Reproduced verbatim:

```
WARNING: Download from https://storage.googleapis.com/rules_docker/aad94363e63d31d574cf701df484b3e8b868a96a/puller-darwin-amd64
         failed: class java.io.IOException GET returned 403 Forbidden
ERROR: no such package '@java_base_image//image': no such package '@go_puller_darwin//file'
ERROR: Analysis of target '//src:image.tar' failed; build aborted
```

Note that the `rules_docker-v0.25.0.tar.gz` release asset itself still returns 200 — only the puller/loader binaries are gone. **Re-pinning the URLs is not an option**: these binaries were only ever published to that bucket, there is no upstream mirror, and `rules_docker` was archived by Google so no replacement will be cut.

### 2. The base image was withdrawn

Even with a working puller, `container_pull(repository = "openjdk", tag = "18")` resolves to `docker.io/library/openjdk:18`, which now 404s on the registry. The `openjdk` Docker Official Image was deprecated and its Linux tags removed; only Windows early-access tags remain. So the base image had to change regardless of which rule set builds it.

### 3. CI would not have honoured `.bazelversion` anyway

`docker.yml` and `test.yml` download **bazelisk v1.1.0**, which predates `.bazeliskrc` support — `USE_BAZEL_VERSION=6.1.2` is silently ignored, and it resolves to the latest Bazel release instead (Bazel 8 today, which `rules_scala` 5.0.0 does not support). Neither workflow pinned a JDK either, despite `.bazelrc` setting `--java_language_version=18`, so they depended on whatever `JAVA_HOME` the runner image happened to ship.

### 4. The Kafka test harness could not start a broker

Separate from the build, and predating this PR: the `test` job's jest suite could never start its Kafka testcontainer. It failed with

```
Log stream ended and message "started (kafka.server.KafkaServer)" was not received
```

which is testcontainers reporting that the container exited. The container's own output (captured by re-running the workflow with `DEBUG=testcontainers*`) shows why — both the embedded ZooKeeper JVM and the broker JVM abort during startup:

```
===> Configuring ...
java.lang.NullPointerException
  at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:81)
  at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:113)
  at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:167)
  ...
  at jdk.management.agent/jdk.internal.agent.Agent.startLocalManagementAgent(Agent.java:318)
  at jdk.management.agent/jdk.internal.agent.Agent.startAgent(Agent.java:599)
Exception thrown by the agent : java.lang.NullPointerException
===> Running preflight checks ...
===> Launching ...
===> Launching kafka ...
java.lang.NullPointerException
  at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:81)
  ...
Exception thrown by the agent : java.lang.NullPointerException
```

This is [JDK-8287073](https://bugs.openjdk.org/browse/JDK-8287073) — under cgroup v2 the JVM's controller detection can hand back a null `CgroupInfo`, and `Container.metrics()` then NPEs. Confluent's `kafka-run-class` enables the JMX agent by default (`KAFKA_JMX_OPTS`), the agent calls `Container.metrics()` on every JVM it starts, and a throwing agent aborts the VM. So both JVMs in the container die within ~3s and the container exits before it can log `started (kafka.server.KafkaServer)`.

Nothing in the harness is wrong; the image's JDK is simply too old for the cgroup layout on current kernels. `cp-kafka:7.2.2` ships Zulu **11.0.16.1**, and the fix landed in **11.0.17**. Same failure as [testcontainers-node#911](https://github.com/testcontainers/testcontainers-node/issues/911).

## What changed

Migrated the image build from the archived `rules_docker` to **`rules_oci`**, following the [rules_oci Scala migration guide](https://github.com/bazel-contrib/rules_oci/blob/main/docs/scala.md) — packaging the `scala_binary` deploy jar into a layer rather than reproducing `scala_image`'s runfiles layout.

**`WORKSPACE`**
- Dropped `io_bazel_rules_docker` and all of its setup.
- Added `rules_oci` 1.8.0, `rules_pkg` 0.9.1, and `aspect_bazel_lib` 2.7.7. bazel-lib is pinned explicitly ahead of `rules_oci_dependencies()`, which would otherwise pull 1.42.1 — that release has no `linux/arm64` jq toolchain, so `oci_image` fails toolchain resolution on arm64 Linux.
- Bumped `bazel_skylib` 1.0.3 → 1.4.2 (needed by bazel-lib 2.x) and called `bazel_skylib_workspace()`.
- `oci_pull` of `eclipse-temurin:18-jdk` pinned by digest `sha256:1b8a5c3f...`, for `linux/amd64` and `linux/arm64/v8`.

**`src/BUILD`**
- Replaced `scala_image` with `pkg_tar` + `oci_image` + `oci_tarball`.
- A `copy_file` republishes the tarball as `image.tar`, so **`bazel build //src:image.tar` still writes `bazel-bin/src/image.tar`** and the loaded image is still tagged **`bazel/src:image`**. The release workflow's `docker load`/`docker tag`/`docker push` block and the `pretest` script in `package.json` are unchanged.

**`.github/workflows/{docker,test}.yml`**
- bazelisk v1.1.0 → v1.20.0, and actually put it on `PATH`.
- Added `actions/setup-java@v4` with Temurin 18, matching `--java_language_version=18`.
- Bumped `actions/checkout@v2` → v4, `setup-node@v2` → v4, `docker/login-action@v1` → v3, `docker/metadata-action@v4` → v5 (the v2/v1 action versions run on retired Node runtimes).
- The DockerHub login already ran before the build; added a comment noting that this ordering now matters, because `oci_pull` reads `~/.docker/config.json` and therefore pulls the base image authenticated rather than anonymously.

**No new secrets.** `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` are the same ones the workflow already used.

**Kafka test harness** — kept as a separate commit (`fix(tests): bump Kafka test image to cp-kafka 7.6.0`) so the two concerns can be reviewed apart.

`confluentinc/cp-kafka:7.2.2` → `7.6.0`, in `tests/testcontainers/kafka.ts` and the `docker pull` in `test.yml`. Two lines. `7.6.0` ships Zulu **11.0.21**, which is past the 11.0.17 fix for JDK-8287073; it still runs Kafka in ZooKeeper mode (`@testcontainers/kafka` 10.2.2 has no KRaft support, so staying on the 7.x/ZK line matters), still emits the `started (kafka.server.KafkaServer)` line the wait strategy matches, and is published for **both `linux/amd64` and `linux/arm64`**. No harness code, wait strategy, or listener config changed.

Bumping the image was preferred over the smaller alternative of blanking `KAFKA_JMX_OPTS` to keep the agent from starting: that suppresses this one symptom but leaves a JDK with known-broken container awareness running the broker, on an image that is three years old and out of support.

### Runtime equivalence

This is intended as a build-system change only.

| | before (`rules_docker`) | after (`rules_oci`) |
|---|---|---|
| Base | `openjdk:18` (JDK 18.0.2.1) | `eclipse-temurin:18-jdk` (JDK 18.0.2.1, digest-pinned) |
| Entrypoint | `/usr/bin/java -cp <jars> Main` | `java -cp /app/dafka-producer.jar Main` |
| Env | `JAVA_RUNFILES=/app` | `JAVA_RUNFILES=/app` |
| App layers | 1 (`scala_image` defaults to no split dep layers) | 1 |
| Loaded tag | `bazel/src:image` | `bazel/src:image` |
| Published tags | `metadata-action` semver | unchanged |
| `EXPOSE` | none | none |
| JVM flags | none | none |

Two deliberate differences, both forced:

- **Base image vendor.** `openjdk:18` no longer exists. `eclipse-temurin` is the successor named in the `openjdk` image's own deprecation notice, and ships the identical `18.0.2.1+1` build — verified in the running container below. `18-jdk` rather than `18-jre` keeps the JDK tooling the old image had.
- **Classpath shape.** `rules_docker` laid individual jars under `/app` and generated a long `-cp`. This uses the `scala_binary` `_deploy.jar`, so the classpath is one entry. Same main class, same JVM, and `logback.xml` plus SLF4J service discovery are confirmed intact by the JSON log output below.

Worth flagging for a **follow-up, not this PR**: Java 18 is a non-LTS release that went end-of-life in September 2022. This PR deliberately holds the Java version constant so the change stays a build fix; moving to `eclipse-temurin:21-jre` would be a small diff on top.

## Verification

Built and run locally. macOS hosts cannot build this repo at all — `@zlib` is pinned at 1.2.11, whose `zutil.h` defines `fdopen` to `NULL` under `TARGET_OS_MAC` and breaks against any current macOS SDK. That is pre-existing on `main`, unrelated to this change, and not something CI hits. So the build was run in a Linux container (`eclipse-temurin:18-jdk` + `build-essential` + bazelisk v1.20.0), which is the same shape as the `ubuntu-latest` job:

```
$ bazel build //src:image.tar
INFO: Analyzed target //src:image.tar (253 packages loaded, 2099 targets configured).
Target //src:image.tar up-to-date:
  bazel-bin/src/image.tar
INFO: Build completed successfully, 298 total actions
```

Re-running is a no-op, so the graph is stable:

```
INFO: Build completed successfully, 1 total action   # 1 internal, everything cached
```

Loads into Docker with the expected config:

```
$ docker load -i bazel-bin/src/image.tar
Loaded image: bazel/src:image

$ docker image inspect bazel/src:image
"Entrypoint": ["java", "-cp", "/app/dafka-producer.jar", "Main"]
"Env": [..., "JAVA_VERSION=jdk-18.0.2.1+1", "JAVA_RUNFILES=/app"]
5 layers, 313011634 bytes

$ docker run --rm --entrypoint java bazel/src:image -version
openjdk version "18.0.2.1" 2022-08-18
OpenJDK Runtime Environment Temurin-18.0.2.1+1 (build 18.0.2.1+1)
```

Boots and serves. Started with `KAFKA_BROKER` pointing at nothing, so the producer cannot connect — that part is expected; the point is that the JVM starts and Blaze binds:

```
$ docker run -d -p 18080:8080 -e KAFKA_BROKER=localhost:9092 -e PORT=8080 bazel/src:image

{"level":"INFO","logger":"org.http4s.blaze.server.BlazeServerBuilder",
 "message":"http4s v0.23.19 on blaze v0.23.15 started at http://[::]:8080/"}
{"level":"INFO","logger":"Main","message":"dafka-producer started"}
{"level":"WARN","logger":"org.apache.kafka.clients.NetworkClient",
 "message":"[Producer clientId=producer-1] Connection to node -1 (localhost/127.0.0.1:9092) could not be established. Broker may not be available."}

$ curl http://localhost:18080/alive     # true  [HTTP 200]
$ curl http://localhost:18080/ready     # true  [HTTP 200]
$ curl http://localhost:18080/metrics   # HELP dafka_producer_active_request_count Total Active Requests.
```

The structured JSON logging confirms `logback.xml` and the SLF4J provider survived the deploy-jar merge, and `/metrics` confirms the Prometheus registry is wired.

**Confirmed on CI — the `test` check on this PR is green:** [run 30900460409](https://github.com/osskit/dafka-producer/actions/runs/30900460409)

```
INFO: Build completed successfully, 213 total actions
Loaded image: bazel/src:image
PASS tests/specs/produceFailure.spec.ts (28.033 s)
PASS tests/specs/produce.spec.ts (35.432 s)
Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
```

That covers what could not be checked locally: the `ubuntu-latest` / `linux-amd64` build of `//src:image.tar` (locally only `linux/arm64` was exercised) and the full closed-box suite, which loads the image this PR builds, produces through it to a real broker, and asserts the messages land. The harness fix was also validated on a scratch branch with `MAX_RETRIES: 1`, so the green is not jest retries papering over flake.

The jest suite still cannot run on this workstation — the local Docker daemon is out of disk and out of bridge address pool space. That is a host limit, unrelated to this change.

**Still not verified:** the `docker push` in `docker.yml`. It only runs on a tag push and cannot be exercised from a PR without publishing an image.

## Unblocks

This is a prerequisite for both open PRs — neither can ship until an image can be published:

- #38 — `KAFKA_PROPERTY_*` passthrough, which is what makes `max.request.size` settable
- #39 — compact JSON instead of the pretty-printed output

**Neither needs a conflict resolution.** #38 touches `README.md`, `src/main/scala/config/KafkaConfig.scala` and `tests/specs/extraKafkaProperties.spec.ts`; #39 touches `src/main/scala/adapters/kafka/ProducerImpl.scala` and `tests/specs/produce.spec.ts`. This PR touches only `WORKSPACE`, `src/BUILD` and the two workflows, so there is no overlap. They do each need to be **updated from `main` after this merges** — not to resolve conflicts, but so their `test` job has a buildable `//src:image.tar` and can actually run.
